### PR TITLE
Small tweaks to tf files

### DIFF
--- a/ssh.tf
+++ b/ssh.tf
@@ -29,9 +29,9 @@ resource "aws_instance" "ssh_host" {
   instance_type = "t2.nano"
   key_name      = "${aws_key_pair.elasticcache.id}"
 
-  subnet_id       = "${element(aws_subnet.default.*.id,0)}"
-  security_groups = ["${aws_security_group.default.id}"]
-  user_data       = "${data.template_file.startup.rendered}"
+  subnet_id              = "${element(aws_subnet.default.*.id,0)}"
+  vpc_security_group_ids = ["${aws_security_group.default.id}"]
+  user_data              = "${data.template_file.startup.rendered}"
 
   tags = "${map(
     "Name", "${var.namespace}-ssh-host",

--- a/variables.tf
+++ b/variables.tf
@@ -1,16 +1,3 @@
-# AWS Specific variables
-variable "aws_region" {
-  description = "AWS region to create the environment"
-}
-
-variable "aws_access_key_id" {
-  description = "AWS access key"
-}
-
-variable "aws_secret_access_key" {
-  description = "AWS secret"
-}
-
 variable "vpc_cidr_block" {
   description = "The top-level CIDR block for the VPC."
   default     = "10.1.0.0/16"


### PR DESCRIPTION
- use `vpc_security_group_ids` to avoid a reoccurring diff (Instances in VPCs need to use `vpc_security_group_ids`)

- remove `aws_` variables, in favor of the AWS elements we've put in the environment. Without this, users will put their crews in the ENV as per instructed in the blog, but still get prompted for them at invocation, and I don't think these variables are actually used 